### PR TITLE
Update example snippet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,18 @@ steps:
     uses: redhat-actions/openshift-cli-installer@v1
     with:
       # Installs the latest camel-k release.
-      - kamel: latest
+      kamel: latest
 
       # Installs the latest release of oc with the major version 3.
       # This is equivalent to "3.x" or "^3".
-      - oc: "3"
+      oc: "3"
 
       # Installs the latest release of odo with the major version 2, and the minor version 0.
       # This would install odo 2.0.3, but not odo 2.1.0.
-      - odo: "2.0"
+      odo: "2.0"
 
       # This exact version will install version 0.11.0 of Tekton, no other version.
-      - tkn: "0.11.0"
+      tkn: "0.11.0"
 ```
 
 ## Outputs


### PR DESCRIPTION
I copied and pasted the example, but it only worked without "-" under `with:`

Test result at - https://github.com/gfvirga/testactions/runs/1738792806?check_suite_focus=true

code - https://github.com/gfvirga/testactions/blob/aa7ae36a082b6988b4033c89b7fcb09dc9b61b82/.github/workflows/test_openshift-cli.yml

[The example](https://github.com/redhat-actions/openshift-cli-installer/blob/main/.github/workflows/example.yml#L26) also does not have `-`